### PR TITLE
:bug: Misspelling vertical align

### DIFF
--- a/src/select-panel/default-item.tsx
+++ b/src/select-panel/default-item.tsx
@@ -12,7 +12,7 @@ interface IDefaultItemRendererProps {
 
 const DefaultRenderer = css({
   "input,span": {
-    verticalAalign: "middle",
+    verticalAlign: "middle",
     margin: 0,
   },
   span: {


### PR DESCRIPTION
Reason: vertical-aalign is not a valid css property.
Fix: Changed verticalAalign to verticalAlign to fix css.