### PR TITLE
[FIX] - adding preventDefault to handleClear

### DIFF
--- a/src/select-panel/index.tsx
+++ b/src/select-panel/index.tsx
@@ -119,8 +119,7 @@ export const SelectPanel = (props: ISelectPanelProps) => {
     setFocusIndex(FocusType.SEARCH);
   };
 
-  const handleClear = e => {
-    e.preventDefault();
+  const handleClear = () => {
     setSearchTextForFilter("");
     setSearchText("");
   };
@@ -190,6 +189,7 @@ export const SelectPanel = (props: ISelectPanelProps) => {
             value={searchText}
           />
           <button
+            type="button"
             className={`${SearchClearButton} search-clear-button`}
             hidden={!searchText}
             onClick={handleClear}

--- a/src/select-panel/index.tsx
+++ b/src/select-panel/index.tsx
@@ -119,7 +119,8 @@ export const SelectPanel = (props: ISelectPanelProps) => {
     setFocusIndex(FocusType.SEARCH);
   };
 
-  const handleClear = () => {
+  const handleClear = e => {
+    e.preventDefault();
     setSearchTextForFilter("");
     setSearchText("");
   };


### PR DESCRIPTION
When using Multiple select in form (e.g I used with react-final-form) when clicking on clear search it submit the form.
