### PR TITLE
:bug fix click outside bug

### DIFF
--- a/src/select-panel/index.tsx
+++ b/src/select-panel/index.tsx
@@ -207,7 +207,7 @@ export const SelectPanel = (props: ISelectPanelProps) => {
           checked={isAllOptionSelected}
           option={selectAllOption}
           onSelectionChanged={selectAllChanged}
-          onClick={() => handleItemClicked(0)}
+          onClick={() => handleItemClicked(1)}
           itemRenderer={ItemRenderer}
           disabled={disabled}
         />


### PR DESCRIPTION
This fixes the issue (https://github.com/harshzalavadiya/react-multi-select-component/issues/118) where clicking outside does not work if user clicks on `Select All`. It did not work as expected because the `<label />` component was not focused. 

Fix is straightforward. Just need to set focus on index `1` instead of `0`.