### PR TITLE
:bug fix onBlur bug

### DIFF
--- a/src/select-panel/select-item.tsx
+++ b/src/select-panel/select-item.tsx
@@ -46,8 +46,7 @@ const SelectItem = ({
 
   useEffect(() => {
     updateFocus();
-    // eslint-disable-next-line
-  }, [focused]);
+  });
 
   const toggleChecked = () => {
     onSelectionChanged(!checked);


### PR DESCRIPTION
This PR aims to provide a full fix to this issue (https://github.com/harshzalavadiya/react-multi-select-component/pull/256). The earlier PR (https://github.com/harshzalavadiya/react-multi-select-component/pull/256) appeared to be a partial fix.

The issue was that if user selects and deselects the same checkbox, the item gets out of focus. Because of that, when user tries to click anywhere to close the dropdown, it does not work as expected. So the root cause is that **IF** a dropdown item is not natively focused, user is unable to activate the `onBlur` event handler.

The bug also appears to be intermittent because if a user selects the checkbox and deselects the checkbox, sometimes the text gets highlighted, which effectively place a focus on the dropdown item. Further, if user were to select a checkbox, and proceeds to select/deselect another checkbox, this bug won't surface because the `focusIndex` in this block of code is updated as seen below -

```
<SelectItem
  focused={focusIndex === tabIndex}
  tabIndex={tabIndex}
  option={o}
  onSelectionChanged={(c) => handleSelectionChanged(o, c)}
  checked={value.find((s) => s.value === o.value) ? true : false}
  onClick={(e) => onClick(e, tabIndex)}
  itemRenderer={ItemRenderer}
  disabled={o.disabled || disabled}
/>
```
And it triggers 

```
useEffect(() => {
  updateFocus();
  // eslint-disable-next-line
}, [focused]);
```
Therefore, my suggested fix is to remove the `focused` prop from the dependency array. It solves the problem. But not sure about possible regression. 

Please let me know if there's any possible regression and I will look into it. 