### PR TITLE
Added second param to dependency array in useEffect

### DIFF
--- a/src/select-panel/select-item.tsx
+++ b/src/select-panel/select-item.tsx
@@ -46,8 +46,7 @@ const SelectItem = ({
 
   useEffect(() => {
     updateFocus();
-    // eslint-disable-next-line
-  }, [focused]);
+  }, [checked, focused]);
 
   const toggleChecked = () => {
     onSelectionChanged(!checked);

--- a/src/select-panel/select-item.tsx
+++ b/src/select-panel/select-item.tsx
@@ -46,6 +46,7 @@ const SelectItem = ({
 
   useEffect(() => {
     updateFocus();
+    // eslint-disable-next-line
   }, [checked, focused]);
 
   const toggleChecked = () => {


### PR DESCRIPTION
This PR aims to provide a fix on the issue(#256). 

If the same checkbox is selected twice, then the dropdown loses focus and does not close when you click outside. Please see the video below and the relevant code [sandbox](https://codesandbox.io/s/youthful-tesla-ocohd). Credits to @mkhbragg.

The issue occur because the `focused` variable does not change when i check and uncheck the same box (I did a `console.log(focused)` in the `select-item.tsx` file). This resulted in the useEffect not being run and the onBlur event being triggered on the second click. 

Suggested solution
```
useEffect(() => {
    updateFocus();
  }, [checked, focused]); 
```

By adding a second parameter, `checked` in the array dependency, the useEffect is being trigger either whenever the check or focused changes. This prevents the dropdown item from losing focus and selection with arrow keys will still work fine.

https://user-images.githubusercontent.com/76419896/105120648-9d7f4c00-5b0d-11eb-8ae9-d1d6dc575e16.mp4



