### PR TITLE
Updated handleClear() method

### DIFF
--- a/src/select-panel/index.tsx
+++ b/src/select-panel/index.tsx
@@ -107,6 +107,7 @@ const SelectPanel = () => {
   const handleClear = () => {
     setSearchTextForFilter("");
     setSearchText("");
+    setFocusIndex(FocusType.SEARCH);
   };
 
   const handleItemClicked = (index: number) => setFocusIndex(index);


### PR DESCRIPTION
On click of clear search button, focus should be on Search box. If focus is not on search box, search content popup is not getting closed when clicked outside on page/form.

Steps to reproduce:

1. Go to demo page: https://codesandbox.io/s/react-multi-select-example-uqtgs
2. Search any random text in search box
3. Click on clear search button
4. Click anywhere outside of multiselect control
5. Focus is not in search box

In this case the search popup should be closed, which is not working currently.

![image](https://user-images.githubusercontent.com/25476310/109262708-0605cb00-7828-11eb-948d-87590cced4c7.png)